### PR TITLE
Add intl extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update && apt-get install -y libzip4
 FROM base as build_extensions
 
 RUN apt-get update && apt-get install -y libzip-dev \
-    && docker-php-ext-install gettext zip \
-    && docker-php-ext-enable gettext zip
+    && docker-php-ext-install gettext zip intl \
+    && docker-php-ext-enable gettext zip intl
 
 FROM composer:2 as staging
 


### PR DESCRIPTION
When analyzing projects that `require: { "ext-intl": "*" }`, `composer-require-checker` will complain because it is unable to figure out which symbols are provided by that extension.

So, we need to install the `intl` extension in the Docker image so its symbols can be detected.
