### PR TITLE
Use @mlocati's extension installer to facilitate installation of PHP extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
 FROM php:8-cli AS base
-RUN apt-get update && apt-get install -y libzip4 libjpeg62-turbo libfreetype6 libpng16-16 libicu72
 
-FROM base AS build_extensions
+ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN apt-get update && apt-get install -y libzip-dev libicu-dev libfreetype-dev libjpeg62-turbo-dev libpng-dev \
-    && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install -j$(nproc) gettext zip intl gd \
-    && docker-php-ext-enable gettext zip intl gd
+RUN install-php-extensions gd intl gettext zip && rm /usr/local/bin/install-php-extensions
 
 FROM composer:2 AS staging
 
@@ -17,12 +13,10 @@ ARG VERSION
 ENV COMPOSER_REQUIRE_CHECKER_VERSION=${VERSION}
 RUN git clone https://github.com/maglnet/ComposerRequireChecker.git /composer-require-checker
 RUN git checkout $VERSION \
-    && composer install --no-progress --no-interaction --no-ansi --no-dev --no-suggest
+    && composer install --no-progress --no-interaction --no-ansi --no-dev
 
 FROM base
 
-COPY --from=build_extensions /usr/local/lib/php /usr/local/lib/php
-COPY --from=build_extensions /usr/local/etc/php /usr/local/etc/php
 COPY --from=staging /composer-require-checker /composer-require-checker
 
 COPY memory.ini /usr/local/etc/php/conf.d/memory.ini


### PR DESCRIPTION
That way, we do not need to take care of installing the required runtime and compile-time dependencies ourselves: The script will take care of that, and it will also remove the compile-time dependencies before the Docker image layer is committed.