### PR TITLE
Use `type=gha` cache for builds in GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,7 @@ jobs:
                     platforms: linux/amd64,linux/arm64
                     cache-from: type=gha
                     cache-to: type=gha,mode=max
+                    pull: true
 
             -   name: Load image for current platform into local Docker
                 uses: docker/build-push-action@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,10 +60,17 @@ jobs:
                     docker buildx create --name builder --use
                     docker buildx build \
                       --progress plain \
-                      --platform=linux/amd64,linux/arm64 \
-                      --cache-from=type=gha \
-                      --cache-to=type=gha,mode=max \
-                      --pull \
+                      --platform linux/amd64 \
+                      --cache-from type=gha \
+                      --build-arg VERSION="$COMPOSER_REQUIRE_CHECKER_VERSION" \
+                      .
+
+            -   name: Cache build results
+                run: |
+                    docker buildx build \
+                      --progress plain \
+                      --platform linux/amd64 \
+                      --cache-to type=gha,mode=max \
                       --build-arg VERSION="$COMPOSER_REQUIRE_CHECKER_VERSION" \
                       .
 
@@ -72,7 +79,6 @@ jobs:
                     # Load image for current platform into local Docker (see https://github.com/docker/buildx/issues/59)
                     docker buildx build \
                       --progress plain \
-                      --cache-from=type=gha \
                       --tag build \
                       --build-arg VERSION="$COMPOSER_REQUIRE_CHECKER_VERSION" \
                       --load .
@@ -85,8 +91,7 @@ jobs:
                 run: |
                     docker buildx build \
                       --progress plain \
-                      --platform=linux/amd64,linux/arm64 \
-                      --cache-from=type=gha \
+                      --platform linux/amd64 \
                       --tag ghcr.io/webfactory/composer-require-checker:"$COMPOSER_REQUIRE_CHECKER_VERSION" \
                       --label org.opencontainers.image.source=https://github.com/webfactory/docker-composer-require-checker \
                       --build-arg VERSION="$COMPOSER_REQUIRE_CHECKER_VERSION" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
                 uses: docker/build-push-action@v6
                 with:
                     build-args: VERSION=${{ env.COMPOSER_REQUIRE_CHECKER_VERSION }}
+                    cache-from: type=gha
                     load: true
                     tags: build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,10 @@ jobs:
             -   name: Build Docker Image
                 uses: docker/build-push-action@v6
                 with:
-                    platform: linux/amd64
+                    build-args: VERSION=${{ env.COMPOSER_REQUIRE_CHECKER_VERSION }}
+                    platforms: linux/amd64,linux/arm64
                     cache-from: type=gha
                     cache-to: type=gha,mode=max
-                    build-args: VERSION=${{ env.COMPOSER_REQUIRE_CHECKER_VERSION }}
 
             -   name: Load image for current platform into local Docker
                 uses: docker/build-push-action@v6
@@ -79,7 +79,7 @@ jobs:
                 uses: docker/build-push-action@v6
                 with:
                     build-args: VERSION=${{ env.COMPOSER_REQUIRE_CHECKER_VERSION }}
-                    platform: linux/amd64
+                    platforms: linux/amd64,linux/arm64
                     push: true
                     tags: ghcr.io/webfactory/composer-require-checker:${{ env.COMPOSER_REQUIRE_CHECKER_VERSION }}
                     labels: org.opencontainers.image.source=https://github.com/webfactory/docker-composer-require-checker

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,16 +28,6 @@ jobs:
 
         steps:
 
-            -   uses: docker/setup-qemu-action@v3
-
-            -   uses: actions/checkout@v4
-
-            -   uses: docker/login-action@v3
-                with:
-                    registry: ghcr.io
-                    username: ${{ github.repository_owner }}
-                    password: ${{ secrets.GITHUB_TOKEN }}
-
             -   name: Determine composer-require-checker version to build
                 run: |
                     if [[ -z "$COMPOSER_REQUIRE_CHECKER_VERSION" ]]; then
@@ -55,47 +45,44 @@ jobs:
                 env:
                     COMPOSER_REQUIRE_CHECKER_VERSION: ${{ github.event.inputs.composer-require-checkerVersion }}
 
-            -   name: Build Docker Image
-                run: |
-                    docker buildx create --name builder --use
-                    docker buildx build \
-                      --progress plain \
-                      --platform linux/amd64 \
-                      --cache-from type=gha \
-                      --build-arg VERSION="$COMPOSER_REQUIRE_CHECKER_VERSION" \
-                      .
+            -   uses: docker/setup-qemu-action@v3
+            -   uses: docker/setup-buildx-action@v3
+            -   uses: actions/checkout@v4
+            -   uses: docker/login-action@v3
+                with:
+                    registry: ghcr.io
+                    username: ${{ github.repository_owner }}
+                    password: ${{ secrets.GITHUB_TOKEN }}
 
-            -   name: Cache build results
-                run: |
-                    docker buildx build \
-                      --progress plain \
-                      --platform linux/amd64 \
-                      --cache-to type=gha,mode=max \
-                      --build-arg VERSION="$COMPOSER_REQUIRE_CHECKER_VERSION" \
-                      .
+            -   name: Build Docker Image
+                uses: docker/build-push-action@v6
+                with:
+                    platform: linux/amd64
+                    cache-from: type=gha
+                    cache-to: type=gha,mode=max
+                    build-args: VERSION=${{ env.COMPOSER_REQUIRE_CHECKER_VERSION }}
+
+            -   name: Load image for current platform into local Docker
+                uses: docker/build-push-action@v6
+                with:
+                    build-args: VERSION=${{ env.COMPOSER_REQUIRE_CHECKER_VERSION }}
+                    load: true
+                    tags: build
 
             -   name: Run smoke tests
                 run: |
-                    # Load image for current platform into local Docker (see https://github.com/docker/buildx/issues/59)
-                    docker buildx build \
-                      --progress plain \
-                      --tag build \
-                      --build-arg VERSION="$COMPOSER_REQUIRE_CHECKER_VERSION" \
-                      --load .
-                    
                     # Check "composer-require-checker --version" output
                     docker run --rm build --version | grep -q $COMPOSER_REQUIRE_CHECKER_VERSION
 
             -   name: Push image to registry
                 if: github.event_name != 'pull_request'
-                run: |
-                    docker buildx build \
-                      --progress plain \
-                      --platform linux/amd64 \
-                      --tag ghcr.io/webfactory/composer-require-checker:"$COMPOSER_REQUIRE_CHECKER_VERSION" \
-                      --label org.opencontainers.image.source=https://github.com/webfactory/docker-composer-require-checker \
-                      --build-arg VERSION="$COMPOSER_REQUIRE_CHECKER_VERSION" \
-                      --push .
+                uses: docker/build-push-action@v6
+                with:
+                    build-args: VERSION=${{ env.COMPOSER_REQUIRE_CHECKER_VERSION }}
+                    platform: linux/amd64
+                    push: true
+                    tags: ghcr.io/webfactory/composer-require-checker:${{ env.COMPOSER_REQUIRE_CHECKER_VERSION }}
+                    labels: org.opencontainers.image.source=https://github.com/webfactory/docker-composer-require-checker
 
             -   name: Delete potentially remaining, untagged container images
                 if: github.event_name != 'pull_request'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM php:8-cli AS base
 
+#RUN ( curl -sSLf https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions -o - || echo 'return 1' ) | sh -s \
+#     gd intl gettext zip
+
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN install-php-extensions gd intl gettext zip && rm /usr/local/bin/install-php-extensions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM php:8-cli AS base
 
-#RUN ( curl -sSLf https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions -o - || echo 'return 1' ) | sh -s \
-#     gd intl gettext zip
-
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
 RUN install-php-extensions gd intl gettext zip && rm /usr/local/bin/install-php-extensions


### PR DESCRIPTION
This uses the `docker/build-push-action@v6` to make use of the `gha` type build cache.

Since we're building a multi-platform image, we need different steps for the multi-platform build and loading the image into the local Docker daemon: The latter step can only be run successfully when not specifying multiple platforms.